### PR TITLE
Clarify the value of agent_name for AWS runner registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,5 +59,6 @@ Optionally the plugin can be used to deploy new versions of TeamCity cloud agent
     }
   ]
 }
-
 ```
+
+When building Amazon AMIs the `agent_name` refers to the `Agent name prefix` configured in the agent profile source.


### PR DESCRIPTION
When using AWS agents we don't have a single agent name, and the
provided example agent_name of "{{build_name}}-{{user `build_number`}}"
doesn't really explain what this value should be.

This was confusing for me when going through the README and trying to
set this up so I assume it will be for others as well.